### PR TITLE
add "audio/mpeg" to allowTypes

### DIFF
--- a/src/Media.php
+++ b/src/Media.php
@@ -17,6 +17,7 @@ class Media extends Uploader
      */
     protected static $allowTypes = [
         "audio/mp3",
+        "audio/mpeg",
         "video/mp4",
     ];
 


### PR DESCRIPTION
Enquanto eu estava estudando o FSPHP, aula 07.07, eu recebi erro quando tentava fazer upload de uma mídia.

Observei que no meu sistema (Linux, rodando LAMPP), ao fazer o upload de um arquivo mp3 o MIME type detectado era "audio/mpeg".

Adicionei "audio/mpeg" ao `$allowTypes` do `src/Media.php` e agora tudo funciona conforme esperado.