### PR TITLE
Add news MIME types to send compressed files using the Windows OP

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -17,8 +17,10 @@ class File extends Uploader
      */
     protected static $allowTypes = [
         "application/zip",
-        'application/x-rar-compressed',
-        'application/x-bzip',
+        "application/x-zip-compressed",
+        "application/x-rar-compressed",
+        "application/octet-stream",
+        "application/x-bzip",
         "application/pdf",
         "application/msword",
         "application/vnd.openxmlformats-officedocument.wordprocessingml.document",


### PR DESCRIPTION
**application/zip** does not work to send .zip files on windows and **application/x-rar-compressed** also does not work for .rar files

For that I added **application/x-zip-compressed** for zip files and **application/octet-stream** for extension .rar