### PR TITLE
Corrige o erro do 'exif_read_data'

### DIFF
--- a/src/Image.php
+++ b/src/Image.php
@@ -68,7 +68,6 @@ class Image extends Uploader
         if ($image['type'] == "image/png") {
             $this->file = imagecreatefrompng($image['tmp_name']);
             $this->ext = "png";
-            $this->checkAngle($image);
             return true;
         }
 


### PR DESCRIPTION
Ocorre um erro ao tentar fazer upload de arquivos PNG (Mesmo com o upload sendo realizado normalmente). Pesquisando eu descobri que 'exif_read_data' funciona apenas com os tipos JPEG e TIFF como diz no manual do php : https://www.php.net/manual/en/function.exif-read-data.php.  Esta correção faz com que a função checkAngle, que usa o 'exif_read_data' não seja chamada para arquivos PNG.