### PR TITLE
Forçando criação de diretórios recursivamente

### DIFF
--- a/src/Uploader.php
+++ b/src/Uploader.php
@@ -83,7 +83,7 @@ abstract class Uploader
     protected function dir(string $dir, int $mode = 0755): void
     {
         if (!file_exists($dir) || !is_dir($dir)) {
-            mkdir($dir, $mode);
+            mkdir($dir, $mode, true);
         }
     }
 


### PR DESCRIPTION
Apesar da função mkdir estar documentada que por default cria diretórios recursivamente, no windows só funcionou após informar o parâmetro manualmente.