### PR TITLE
Add new Version 8 to requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     }
   ],
   "require": {
-    "php": "^7.2",
+    "php": "^7.2|^8.0",
     "ext-gd": "*",
     "ext-mbstring": "*",
     "ext-exif": "*"


### PR DESCRIPTION
It's a small update to solve a problem that I had recently. When i try install this lib show a error that requires version 7.1 or 7.2. I think that changing the requirements versions solve this problem.