### PR TITLE
Upload de imagens com extensão alterada

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+/example/uploads
 .git
 .idea

--- a/src/Image.php
+++ b/src/Image.php
@@ -60,6 +60,11 @@ class Image extends Uploader
     {
         if ($image['type'] == "image/jpeg") {
             $this->file = imagecreatefromjpeg($image['tmp_name']);
+
+            if (!$this->file) {
+                $this->file = imagecreatefromstring(file_get_contents($image['tmp_name']));
+            }
+
             $this->ext = "jpg";
             $this->checkAngle($image);
             return true;
@@ -67,6 +72,11 @@ class Image extends Uploader
 
         if ($image['type'] == "image/png") {
             $this->file = imagecreatefrompng($image['tmp_name']);
+
+            if (!$this->file) {
+                $this->file = imagecreatefromstring(file_get_contents($image['tmp_name']));
+            }
+
             $this->ext = "png";
             return true;
         }


### PR DESCRIPTION
Ao tentar efetuar o upload de imagens com extensão alterada (imagens que teve sua extensão renomeada) ocorria um warning e logo após um fatal error.
Com essa alteração caso o upload não seja efetuado utilizando as funções `imagecreatefromjpeg` e `imagecreatefrompng` ele efetua o upload utilizando a função `imagecreatefromstring` .