### PR TITLE
Removed Deprecated UTF8-decode

### DIFF
--- a/src/Uploader.php
+++ b/src/Uploader.php
@@ -67,13 +67,16 @@ abstract class Uploader
      */
     protected function name(string $name): string
     {
-        $name = filter_var(mb_strtolower($name), FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+        $name = filter_var(mb_strtolower($name), FILTER_SANITIZE_SPECIAL_CHARS);
         $formats = 'ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜüÝÞßàáâãäåæçèéêëìíîïðñòóôõöøùúûýýþÿRr"!@#$%&*()_-+={[}]/?;:.,\\\'<>°ºª';
         $replace = 'aaaaaaaceeeeiiiidnoooooouuuuuybsaaaaaaaceeeeiiiidnoooooouuuyybyrr                                 ';
         $name = str_replace(
             ["-----", "----", "---", "--"],
             "-",
-            str_replace(" ", "-", trim(strtr(utf8_decode($name), utf8_decode($formats), $replace)))
+            str_replace(" ", "-", trim(strtr(
+                    mb_convert_encoding($name, "ISO-8859-1", "UTF-8"),
+                    mb_convert_encoding($formats, "ISO-8859-1", "UTF-8"), $replace))
+            )
         );
 
         $this->name = "{$name}." . $this->ext;


### PR DESCRIPTION
Removido a função [utf8_decode](https://wiki.php.net/rfc/remove_utf8_decode_and_utf8_encode) que foi descontinuado no php 8.2 e no lugar foi adicionado a função mb_convert_encoding.

Uma outra mudança foi a troca do filtro "FILTER_SANITIZE_FULL_SPECIAL_CHARS" pelo "FILTER_SANITIZE_SPECIAL_CHARS", pois o filtro estava alterando o nome quando utilizado algum tipo de acento.

Por exemplo

Salvando uma imagem com o nome "ÁÁÁÁ", na pasta de upload o nome está vindo como "aacute-aacute-aacute-aacute.jpg"

![image](https://user-images.githubusercontent.com/28196582/215004984-b887fd0c-6535-402c-bd1f-7bd2cee86829.png)