### PR TITLE
Pequena correção

### DIFF
--- a/src/Uploader.php
+++ b/src/Uploader.php
@@ -116,11 +116,11 @@ abstract class Uploader
      */
     protected function ext(array $file): void
     {
-        $info =  pathinfo($file['name']);
-        if(!empty($info['extension'])){
-            $this->ext = $info['extension'];
-        }
+        $info = pathinfo($file['name']);
         $this->ext = '';
+        if (!empty($info['extension'])) {
+            $this->ext = mb_strtolower($info['extension']);
+        }
     }
 
     /**

--- a/src/Uploader.php
+++ b/src/Uploader.php
@@ -116,7 +116,11 @@ abstract class Uploader
      */
     protected function ext(array $file): void
     {
-        $this->ext = mb_strtolower(pathinfo($file['name'])['extension']);
+        $info =  pathinfo($file['name']);
+        if(!empty($info['extension'])){
+            $this->ext = $info['extension'];
+        }
+        $this->ext = '';
     }
 
     /**


### PR DESCRIPTION
Verifica se o arquivo possui extensão, evitando a mensagem de erro: `Warning: Undefined array key "extension" `
```php
protected function ext(array $file): void{
        $info = pathinfo($file['name']);
        $this->ext ='';
        if (!empty($info['extension'])) {
            $this->ext = mb_strtolower($info['extension']);
        }
    }
```